### PR TITLE
Bump path-parse version to fix CVE-2021-23343

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "vitalam-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^4.7.2",
@@ -4899,9 +4899,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-to-regexp": {
@@ -6942,7 +6942,9 @@
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-6.3.1.tgz",
       "integrity": "sha512-uVWhdd4TVtLc4R2OtiKHJE5jgJZnuEognbgjl5RT2uKrCJYTsYnq0IeRTvMmtdPJAJvGeD3JTsX2ekgt3tJpuw==",
       "requires": {
-        "@babel/runtime": "^7.13.17"
+        "@babel/runtime": "^7.13.17",
+        "@polkadot/util": "6.3.1",
+        "@polkadot/util-crypto": "6.3.1"
       }
     },
     "@polkadot/metadata": {
@@ -7042,6 +7044,7 @@
       "requires": {
         "@babel/runtime": "^7.13.17",
         "@polkadot/networks": "6.3.1",
+        "@polkadot/util": "6.3.1",
         "@polkadot/wasm-crypto": "^4.0.2",
         "@polkadot/x-randomvalues": "6.3.1",
         "base-x": "^3.0.8",
@@ -10408,9 +10411,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalam-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "VITALam API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `path-parse` to 1.0.7