### PR TITLE
Multiple chain metadata values

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Github CODEOWNERS file
 
 # Global code-owners for this repository
-* @chris-digicat @mattdean-digicatapult @callumhyland-dc @jonmattgray
+* @mattdean-digicatapult @darrylmorton-digicatapult @dblane-digicatapult @jonmattgray

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following environment variables are used by `vitalam-api` and can be configu
 | AUTH_ISSUER         |    Y     |    -    | Domain of the Auth0 API e.g. `https://test.eu.auth0.com/`                                                            |
 | AUTH_TOKEN_URL      |    Y     |    -    | Auth0 API endpoint that issues an Authorisation (Bearer) access token e.g. `https://test.auth0.com/oauth/token`      |
 | LEGACY_METADATA_KEY |    N     |   ''    | Key given to token metadata posted without a key (such as when posted using the legacy `metadataFile` field)         |
+| METADATA_KEY_LENGTH |    N     |  `32`   | Fixed length of metadata keys                                                                                        |
 
 ## Running the API
 

--- a/app/env.js
+++ b/app/env.js
@@ -19,6 +19,7 @@ const vars = envalid.cleanEnv(process.env, {
   AUTH_AUDIENCE: envalid.str(),
   AUTH_ISSUER: envalid.url(),
   AUTH_TOKEN_URL: envalid.url(),
+  LEGACY_METADATA_KEY: envalid.str({ default: '' }),
 })
 
 module.exports = {

--- a/app/env.js
+++ b/app/env.js
@@ -20,6 +20,7 @@ const vars = envalid.cleanEnv(process.env, {
   AUTH_ISSUER: envalid.url(),
   AUTH_TOKEN_URL: envalid.url(),
   LEGACY_METADATA_KEY: envalid.str({ default: '' }),
+  METADATA_KEY_LENGTH: envalid.num({ default: 32 }),
 })
 
 module.exports = {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -140,18 +140,9 @@ router.post('/run-process', async (req, res) => {
       outputs = await Promise.all(
         outputs.map(async (output) => ({
           owner: output.owner,
-          metadata: await processMultipleMetadata(output.metadata, files),
+          metadata: await processMetadata(output.metadata, files),
         }))
       )
-
-      // const outputs = await Promise.all(
-      //   request.outputs.map(async (output) => ({
-      //     owner: output.owner,
-      //     metadata: await processMetadata(files[output.metadataFile]),
-      //   }))
-      // )
-
-      //&& request.outputs.every((o) => files[o.metadataFile])
 
       const result = await runProcess(request.inputs, outputs)
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -155,7 +155,7 @@ router.post('/run-process', async (req, res) => {
               metadata: await processMetadata(output.metadata, files),
             }
           } catch (err) {
-            res.status(400).send(err.message)
+            res.status(400).json({ message: err.message })
           }
         })
       )

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -11,7 +11,7 @@ const {
   getReadableMetadataKeys,
 } = require('../util/appUtil')
 const logger = require('../logger')
-const { LEGACY_METADATA_KEY } = require('../env')
+const { LEGACY_METADATA_KEY, METADATA_KEY_LENGTH } = require('../env')
 
 const router = express.Router()
 
@@ -60,8 +60,11 @@ const getMetadataResponse = async (id, metadataKey, res) => {
     const { metadata, id: getId } = await getItem(id)
     if (getId === id) {
       try {
-        const metadataKeyAsHex = `0x${Buffer.from(metadataKey).toString('hex')}`
-        const hash = metadata[metadataKeyAsHex]
+        const buffer = Buffer.alloc(METADATA_KEY_LENGTH) // metadata keys are fixed length
+        const metadataKeyBuf = Buffer.from(metadataKey)
+        metadataKeyBuf.copy(buffer, 0)
+        const metadataKeyAsPaddedHex = `0x${buffer.toString('hex')}`
+        const hash = metadata[metadataKeyAsPaddedHex]
         if (!hash) {
           res.status(404).json({ message: `No metadata with key '${metadataKey}' for token with ID: ${id}` })
           return

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -61,10 +61,9 @@ const getMetadataResponse = async (id, metadataKey, res) => {
     if (getId === id) {
       try {
         const buffer = Buffer.alloc(METADATA_KEY_LENGTH) // metadata keys are fixed length
-        const metadataKeyBuf = Buffer.from(metadataKey)
-        metadataKeyBuf.copy(buffer, 0)
-        const metadataKeyAsPaddedHex = `0x${buffer.toString('hex')}`
-        const hash = metadata[metadataKeyAsPaddedHex]
+        buffer.write(metadataKey)
+        const metadataKeyHex = `0x${buffer.toString('hex')}`
+        const hash = metadata[metadataKeyHex]
         if (!hash) {
           res.status(404).json({ message: `No metadata with key '${metadataKey}' for token with ID: ${id}` })
           return

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -81,6 +81,7 @@ async function processMetadata(metadata, files) {
     metadata.map(async (item) => {
       for (const [key, value] of Object.entries(item)) {
         const file = files[value]
+        if (!file) throw new Error(`Error no attached file found for ${value}`)
         const filestoreResponse = await addFile(file)
         return { [key]: generateHash(filestoreResponse) }
       }

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -67,15 +67,6 @@ async function addFile(file) {
   return json
 }
 
-async function processMetadata(file) {
-  if (file) {
-    const filestoreResponse = await addFile(file)
-    return generateHash(filestoreResponse)
-  }
-
-  return null
-}
-
 function generateHash(filestoreResponse) {
   // directory has no Name
   const dir = filestoreResponse.find((r) => r.Name === '')
@@ -85,7 +76,7 @@ function generateHash(filestoreResponse) {
   }
 }
 
-async function processMultipleMetadata(metadata, files) {
+async function processMetadata(metadata, files) {
   return await Promise.all(
     metadata.map(async (item) => {
       for (const [key, value] of Object.entries(item)) {
@@ -199,7 +190,6 @@ module.exports = {
   getItem,
   getLastTokenId,
   processMetadata,
-  processMultipleMetadata,
   getMetadata,
   validateTokenIds,
 }

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -65,7 +65,7 @@ async function addFile(file) {
   return json
 }
 
-function generateHash(filestoreResponse) {
+function formatHash(filestoreResponse) {
   // directory has no Name
   const dir = filestoreResponse.find((r) => r.Name === '')
   if (dir && dir.Hash && dir.Size) {
@@ -77,11 +77,11 @@ function generateHash(filestoreResponse) {
 async function processMetadata(metadata, files) {
   return Object.fromEntries(
     await Promise.all(
-      Object.entries(metadata).map(async ([key, value]) => {
-        const file = files[value]
-        if (!file) throw new Error(`Error no attached file found for ${value}`)
+      Object.entries(metadata).map(async ([key, filename]) => {
+        const file = files[filename]
+        if (!file) throw new Error(`Error no attached file found for ${filename}`)
         const filestoreResponse = await addFile(file)
-        return [key, generateHash(filestoreResponse)]
+        return [key, formatHash(filestoreResponse)]
       })
     )
   )

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -19,6 +19,8 @@ const metadata = {
     PeerId: '(Vec<u8>)',
     TokenId: 'u128',
     TokenMetadata: 'Hash',
+    // TokenMetadataKey: '(Vec<u8>)',
+    // TokenMetadataValue: 'Hash',
     Token: {
       id: 'TokenId',
       owner: 'AccountId',
@@ -26,6 +28,7 @@ const metadata = {
       created_at: 'BlockNumber',
       destroyed_at: 'Option<BlockNumber>',
       metadata: 'TokenMetadata',
+      //metadata: 'BTreeMap<TokenMetadataKey, TokenMetadataValue>',
       parents: 'Vec<TokenId>',
       children: 'Option<Vec<TokenId>>',
     },
@@ -167,10 +170,20 @@ async function getMetadata(base64Hash) {
   return downloadFile(base58Hash)
 }
 
+const validateTokenIds = async (ids) => {
+  return await ids.reduce(async (acc, inputId) => {
+    const uptoNow = await acc
+    if (!uptoNow || !inputId || !Number.isInteger(inputId)) return false
+    const { id: echoId, children } = await getItem(inputId)
+    return children === null && echoId === inputId
+  }, Promise.resolve(true))
+}
+
 module.exports = {
   runProcess,
   getItem,
   getLastTokenId,
   processMetadata,
   getMetadata,
+  validateTokenIds,
 }

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -18,7 +18,7 @@ const metadata = {
     LookupSource: 'MultiAddress',
     PeerId: '(Vec<u8>)',
     TokenId: 'u128',
-    TokenMetadataKey: '[u8; 32]',
+    TokenMetadataKey: `[u8; ${METADATA_KEY_LENGTH}]`,
     TokenMetadataValue: 'Hash',
     Token: {
       id: 'TokenId',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitalam-api",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitalam-api",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^4.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vitalam-api",
       "version": "2.0.1",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalam-api",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "VITALam API",
   "repository": {
     "type": "git",

--- a/test/helper/appHelper.js
+++ b/test/helper/appHelper.js
@@ -13,6 +13,7 @@ function assertItem(actualResult, expectedResult) {
   } else {
     expect(actualResult.destroyed_at).to.not.equal(null)
   }
+  expect(actualResult.metadata).to.deep.equal(expectedResult.metadata)
 }
 
 module.exports = {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -55,7 +55,7 @@ async function addFileRouteLegacy(file) {
   return body.json()
 }
 
-async function addItemRoute(app, authToken, inputs, outputs) {
+async function postRunProcess(app, authToken, inputs, outputs) {
   let req = request(app)
     .post('/run-process')
     .set('Accept', 'application/json')
@@ -91,6 +91,30 @@ async function addItemRoute(app, authToken, inputs, outputs) {
     })
 }
 
+async function postRunProcessNoFileAttach(app, authToken, inputs, outputs) {
+  let req = request(app)
+    .post('/run-process')
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .set('Authorization', `Bearer ${authToken}`)
+    .field(
+      'request',
+      JSON.stringify({
+        inputs,
+        outputs,
+      })
+    )
+
+  return req
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`addItemErr ${err}`)
+      return err
+    })
+}
+
 async function getItemRoute(app, authToken, { id }) {
   return request(app)
     .get(`/item/${id}`)
@@ -106,7 +130,22 @@ async function getItemRoute(app, authToken, { id }) {
     })
 }
 
-async function getItemMetadataRoute(app, authToken, { id }) {
+async function getItemMetadataRoute(app, authToken, { id, metadataKey }) {
+  return request(app)
+    .get(`/item/${id}/metadata/${metadataKey}`)
+    .set('Accept', 'application/octet-stream')
+    .set('Content-Type', 'application/octet-stream')
+    .set('Authorization', `Bearer ${authToken}`)
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`getItemErr ${err}`)
+      return err
+    })
+}
+
+async function getItemMetadataRouteLegacy(app, authToken, { id }) {
   return request(app)
     .get(`/item/${id}/metadata`)
     .set('Accept', 'application/octet-stream')
@@ -139,10 +178,12 @@ async function getLastTokenIdRoute(app, authToken) {
 module.exports = {
   healthCheck,
   getAuthTokenRoute,
-  addItemRoute,
+  postRunProcess,
+  postRunProcessNoFileAttach,
   addFileRoute,
   addFileRouteLegacy,
   getItemRoute,
   getItemMetadataRoute,
+  getItemMetadataRouteLegacy,
   getLastTokenIdRoute,
 }

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -69,9 +69,19 @@ async function addItemRoute(app, authToken, inputs, outputs) {
       })
     )
 
-  req = outputs.reduce((acc, { metadataFile }) => {
-    return req.attach(metadataFile, metadataFile)
-  }, req)
+  outputs.forEach((output) => {
+    if (output.metadata) {
+      output.metadata.map(async (item) => {
+        for (const fileName of Object.values(item)) {
+          req.attach(fileName, fileName)
+        }
+      })
+    }
+    // legacy
+    if (output.metadataFile) {
+      req.attach(output.metadataFile, output.metadataFile)
+    }
+  })
 
   return req
     .then((response) => {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -71,11 +71,9 @@ async function addItemRoute(app, authToken, inputs, outputs) {
 
   outputs.forEach((output) => {
     if (output.metadata) {
-      output.metadata.map(async (item) => {
-        for (const fileName of Object.values(item)) {
-          req.attach(fileName, fileName)
-        }
-      })
+      for (const fileName of Object.values(output.metadata)) {
+        req.attach(fileName, fileName)
+      }
     }
     // legacy
     if (output.metadataFile) {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -196,7 +196,7 @@ describe('routes', function () {
 
       const base64Metadata = `0x${bs58.decode(base58Metadata).toString('hex').slice(4)}`
 
-      const output = { owner: USER_ALICE_TOKEN, metadata: base64Metadata }
+      const output = { owner: USER_ALICE_TOKEN, metadata: { '': base64Metadata } }
 
       await runProcess([], [output])
 
@@ -206,13 +206,13 @@ describe('routes', function () {
       expect(res.header['content-disposition']).equal('attachment; filename="test_file_01.txt"')
     })
 
-    test('get legacy item metadata', async function () {
+    test('get item metadata (addFileRouteLegacy)', async function () {
       const lastToken = await getLastTokenIdRoute(app, authToken)
       const lastTokenId = lastToken.body.id
       const { Hash: base58Metadata } = await addFileRouteLegacy('./test/data/test_file_01.txt')
       const base64Metadata = `0x${bs58.decode(base58Metadata).toString('hex').slice(4)}`
 
-      const output = { owner: USER_ALICE_TOKEN, metadata: base64Metadata }
+      const output = { owner: USER_ALICE_TOKEN, metadata: { '': base64Metadata } }
 
       await runProcess([], [output])
 
@@ -240,7 +240,7 @@ describe('routes', function () {
       expect(actualResult.body).to.have.property('message')
     })
 
-    test.only('run-process creating one token (legacy)', async function () {
+    test('run-process creating one token (legacy)', async function () {
       const lastToken = await getLastTokenIdRoute(app, authToken)
       const lastTokenId = lastToken.body.id
 

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -19,7 +19,7 @@ const USER_ALICE_TOKEN = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 const USER_BOB_TOKEN = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
 const { createToken, assertItem } = require('../helper/appHelper')
 const { processMetadata, runProcess } = require('../../app/util/appUtil')
-const { AUTH_TOKEN_URL, AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
+const { AUTH_TOKEN_URL, AUTH_ISSUER, AUTH_AUDIENCE, LEGACY_METADATA_KEY } = require('../../app/env')
 
 const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 const bs58 = require('base-x')(BASE58)
@@ -127,7 +127,7 @@ describe('routes', function () {
       await jwksMock.stop()
     })
 
-    test.only('add and get item - single metadataFile (legacy)', async function () {
+    test('add and get item - single metadataFile (legacy)', async function () {
       const outputs = [{ owner: USER_ALICE_TOKEN, metadataFile: './test/data/test_file_01.txt' }]
       const addItemResult = await addItemRoute(app, authToken, [], outputs)
       expect(addItemResult.body).to.have.length(1)
@@ -141,8 +141,8 @@ describe('routes', function () {
       expect(getItemResult.body.id).to.deep.equal(lastToken.body.id)
     })
 
-    test.only('add and get item - metadata object - single file', async function () {
-      const outputs = [{ owner: USER_ALICE_TOKEN, metadata: [{ testFile: './test/data/test_file_01.txt' }] }]
+    test('add and get item - metadata object - single file', async function () {
+      const outputs = [{ owner: USER_ALICE_TOKEN, metadata: { testFile: './test/data/test_file_01.txt' } }]
       const addItemResult = await addItemRoute(app, authToken, [], outputs)
       expect(addItemResult.body).to.have.length(1)
       expect(addItemResult.status).to.equal(200)
@@ -155,11 +155,11 @@ describe('routes', function () {
       expect(getItemResult.body.id).to.deep.equal(lastToken.body.id)
     })
 
-    test.only('add and get item - metadata object - multiple files', async function () {
+    test('add and get item - metadata object - multiple files', async function () {
       const outputs = [
         {
           owner: USER_ALICE_TOKEN,
-          metadata: [{ testFile1: './test/data/test_file_01.txt', testFile2: './test/data/test_file_02.txt' }],
+          metadata: { testFile1: './test/data/test_file_01.txt', testFile2: './test/data/test_file_02.txt' },
         },
       ]
       const addItemResult = await addItemRoute(app, authToken, [], outputs)
@@ -240,7 +240,7 @@ describe('routes', function () {
       expect(actualResult.body).to.have.property('message')
     })
 
-    test('run-process creating one token', async function () {
+    test.only('run-process creating one token (legacy)', async function () {
       const lastToken = await getLastTokenIdRoute(app, authToken)
       const lastTokenId = lastToken.body.id
 
@@ -263,11 +263,41 @@ describe('routes', function () {
         owner: USER_BOB_TOKEN,
         parents: [],
         children: null,
+        metadata: [LEGACY_METADATA_KEY],
       }
 
       assertItem(item.body, expectedResult)
       expect(itemMetadata.text.toString()).equal('This is the fourth test file...\n')
     })
+
+    // test.only('run-process creating one token', async function () {
+    //   const lastToken = await getLastTokenIdRoute(app, authToken)
+    //   const lastTokenId = lastToken.body.id
+
+    //   let expectedResult = [lastTokenId + 1]
+
+    //   const outputs = [{ owner: USER_BOB_TOKEN, metadata: { testFile: './test/data/test_file_01.txt' } }]
+    //   const actualResult = await addItemRoute(app, authToken, [], outputs)
+
+    //   expect(actualResult.status).to.equal(200)
+    //   expect(actualResult.body).to.deep.equal(expectedResult)
+
+    //   const item = await getItemRoute(app, authToken, { id: lastTokenId + 1 })
+    //   const itemMetadata = await getItemMetadataRoute(app, authToken, {
+    //     id: lastTokenId + 1,
+    //   })
+
+    //   expectedResult = {
+    //     id: lastTokenId + 1,
+    //     creator: USER_ALICE_TOKEN,
+    //     owner: USER_BOB_TOKEN,
+    //     parents: [],
+    //     children: null,
+    //   }
+
+    //   assertItem(item.body, expectedResult)
+    //   expect(itemMetadata.text.toString()).equal('This is the fourth test file...\n')
+    // })
 
     test('run-process destroying one token and creating one', async function () {
       const lastToken = await getLastTokenIdRoute(app, authToken)

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -107,7 +107,7 @@ describe('routes', function () {
     })
   })
 
-  describe('authenticated routes', function () {
+  describe.only('authenticated routes', function () {
     let app
     let jwksMock
     let authToken

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -127,7 +127,7 @@ describe('routes', function () {
       await jwksMock.stop()
     })
 
-    test('add and get item - single metadataFile (legacy)', async function () {
+    test.only('add and get item - single metadataFile (legacy)', async function () {
       const outputs = [{ owner: USER_ALICE_TOKEN, metadataFile: './test/data/test_file_01.txt' }]
       const addItemResult = await addItemRoute(app, authToken, [], outputs)
       expect(addItemResult.body).to.have.length(1)

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -188,7 +188,7 @@ describe('routes', function () {
       expect(actualResult.body).to.have.property('message')
     })
 
-    test('get item metadata', async function () {
+    test('get legacy item metadata', async function () {
       const lastToken = await getLastTokenIdRoute(app, authToken)
       const lastTokenId = lastToken.body.id
       const dir = await addFileRoute('./test/data/test_file_01.txt')

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -127,8 +127,41 @@ describe('routes', function () {
       await jwksMock.stop()
     })
 
-    test('add and get item', async function () {
+    test('add and get item - single metadataFile (legacy)', async function () {
       const outputs = [{ owner: USER_ALICE_TOKEN, metadataFile: './test/data/test_file_01.txt' }]
+      const addItemResult = await addItemRoute(app, authToken, [], outputs)
+      expect(addItemResult.body).to.have.length(1)
+      expect(addItemResult.status).to.equal(200)
+
+      const lastToken = await getLastTokenIdRoute(app, authToken)
+      expect(lastToken.body).to.have.property('id')
+
+      const getItemResult = await getItemRoute(app, authToken, lastToken.body)
+      expect(getItemResult.status).to.equal(200)
+      expect(getItemResult.body.id).to.deep.equal(lastToken.body.id)
+    })
+
+    test.only('add and get item - metadata object - single file', async function () {
+      const outputs = [{ owner: USER_ALICE_TOKEN, metadata: [{ testFile: './test/data/test_file_01.txt' }] }]
+      const addItemResult = await addItemRoute(app, authToken, [], outputs)
+      expect(addItemResult.body).to.have.length(1)
+      expect(addItemResult.status).to.equal(200)
+
+      const lastToken = await getLastTokenIdRoute(app, authToken)
+      expect(lastToken.body).to.have.property('id')
+
+      const getItemResult = await getItemRoute(app, authToken, lastToken.body)
+      expect(getItemResult.status).to.equal(200)
+      expect(getItemResult.body.id).to.deep.equal(lastToken.body.id)
+    })
+
+    test.only('add and get item - metadata object - multiple files', async function () {
+      const outputs = [
+        {
+          owner: USER_ALICE_TOKEN,
+          metadata: [{ testFile1: './test/data/test_file_01.txt', testFile2: './test/data/test_file_02.txt' }],
+        },
+      ]
       const addItemResult = await addItemRoute(app, authToken, [], outputs)
       expect(addItemResult.body).to.have.length(1)
       expect(addItemResult.status).to.equal(200)


### PR DESCRIPTION
Backwards compatible API changes to match https://github.com/digicatapult/vitalam-node/pull/8

Token metadata is now added with `metadata: {KEY: FILENAME, KEY2: FILENAME, ...}` rather than `metadataFile: FILENAME`.

`metadataFile: FILENAME` can still be used.  Files uploaded with `metadataFile` use `LEGACY_METADATA_KEY` env for their key.

As metadata keys are fixed length, the API adds padding when minting new tokens (`/run-process`) and removes padding when returning metadata keys (`/item/:id`) for a token.

- [x] `/run-process` accepts single or multiple metadata values.
- [x] `/item/:id/metadata` now a legacy route for old tokens with a single metadata value.
- [x]  `/item/:id` now also returns `metadata: [metadataKey]`
- [x] new `/item/:id/metadata/:metadataKey` route
- [x] handles fixed length keys to match node `TokeMetadataKey` type of `[u8; 32]` 
- [x] tests for above
- [x] README update for above
- [x] `vitalam-demo-client` working with new node + API

