### PR TITLE
Add missing headers for metadata files

### DIFF
--- a/app/api-v2/routes/run-process.js
+++ b/app/api-v2/routes/run-process.js
@@ -59,19 +59,17 @@ module.exports = function (apiService) {
             parentIndices.add(output.parent_index)
           }
 
-          try {
-            return {
-              roles: await processRoles(output.roles),
-              metadata: await processMetadata(output.metadata, req.files),
-              parent_index: output.parent_index,
-            }
-          } catch (err) {
-            logger.trace(`Invalid outputs: ${err.message}`)
-            res.status(400).json({ message: err.message })
-            return
+          return {
+            roles: await processRoles(output.roles),
+            metadata: await processMetadata(output.metadata, req.files),
+            parent_index: output.parent_index,
           }
         })
-      )
+      ).catch((err) => {
+        logger.trace(`Invalid outputs: ${err.message}`)
+        res.status(400).json({ message: err.message })
+        return
+      })
 
       let result
       try {

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -441,7 +441,9 @@ const getMetadataResponse = async (tokenId, metadataKey, res) => {
       res.set({
         immutable: true,
         maxAge: 365 * 24 * 60 * 60 * 1000,
-        'Content-Disposition': `attachment; filename="${file.filename}"`,
+        'content-disposition': `attachment; filename="${file.filename}"`,
+        'access-control-expose-headers': 'content-disposition',
+        'content-type': 'application/octet-stream',
       })
       file.file.pipe(res)
       file.file.on('error', (err) => reject(err))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitalam-api",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitalam-api",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalam-api",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "VITALam API",
   "repository": {
     "type": "git",

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -251,6 +251,7 @@ describe('routes', function () {
         })
         expect(testFile.text.toString()).equal('This is the first test file...\n')
         expect(testFile.header['content-disposition']).equal('attachment; filename="test_file_01.txt"')
+        expect(testLiteral.header['content-type']).equal('application/octet-stream')
 
         const testLiteral = await getItemMetadataRoute(app, authToken, {
           id: lastToken.body.id,
@@ -391,6 +392,7 @@ describe('routes', function () {
 
         expect(res.text.toString()).equal('This is the first test file...\n')
         expect(res.header['content-disposition']).equal('attachment; filename="test_file_01.txt"')
+        expect(res.header['content-type']).equal('application/octet-stream')
       })
 
       test('run-process creating one token', async function () {
@@ -879,6 +881,7 @@ describe('routes', function () {
 
         expect(res.text.toString()).equal('This is the first test file...\n')
         expect(res.header['content-disposition']).equal('attachment; filename="metadata"')
+        expect(res.header['content-type']).equal('application/octet-stream')
       })
     })
   })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -249,9 +249,9 @@ describe('routes', function () {
           id: lastToken.body.id,
           metadataKey: 'testFile',
         })
-        expect(testFile.text.toString()).equal('This is the first test file...\n')
+        expect(testFile.body.toString('utf8')).equal('This is the first test file...\n')
         expect(testFile.header['content-disposition']).equal('attachment; filename="test_file_01.txt"')
-        expect(testLiteral.header['content-type']).equal('application/octet-stream')
+        expect(testFile.header['content-type']).equal('application/octet-stream')
 
         const testLiteral = await getItemMetadataRoute(app, authToken, {
           id: lastToken.body.id,
@@ -390,7 +390,7 @@ describe('routes', function () {
 
         const res = await getItemMetadataRoute(app, authToken, { id: lastTokenId + 1, metadataKey: 'testFile' })
 
-        expect(res.text.toString()).equal('This is the first test file...\n')
+        expect(res.body.toString('utf8')).equal('This is the first test file...\n')
         expect(res.header['content-disposition']).equal('attachment; filename="test_file_01.txt"')
         expect(res.header['content-type']).equal('application/octet-stream')
       })
@@ -425,7 +425,7 @@ describe('routes', function () {
           id: lastTokenId + 1,
           metadataKey: 'testFile',
         })
-        expect(itemMetadata.text.toString()).equal('This is the first test file...\n')
+        expect(itemMetadata.body.toString('utf8')).equal('This is the first test file...\n')
       })
 
       test('run-process destroying one token and creating one', async function () {
@@ -863,7 +863,7 @@ describe('routes', function () {
         const itemMetadata = await getItemMetadataRouteLegacy(app, authToken, {
           id: lastTokenId + 1,
         })
-        expect(itemMetadata.text.toString()).equal('This is the fourth test file...\n')
+        expect(itemMetadata.body.toString('utf8')).equal('This is the fourth test file...\n')
       })
 
       test('get item metadata - direct add file (addFileRouteLegacy)', async function () {
@@ -879,7 +879,7 @@ describe('routes', function () {
 
         const res = await getItemMetadataRoute(app, authToken, { id: lastTokenId + 1, metadataKey: 'testFile' })
 
-        expect(res.text.toString()).equal('This is the first test file...\n')
+        expect(res.body.toString('utf8')).equal('This is the first test file...\n')
         expect(res.header['content-disposition']).equal('attachment; filename="metadata"')
         expect(res.header['content-type']).equal('application/octet-stream')
       })


### PR DESCRIPTION
Adds headers that l've discovered the front-end needs to correctly handle files.

Also moves an incorrectly placed catch block for a `Promise.all`. 
