### PR TITLE
Add timestamp to GET /item/:id

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Gets the item identified by `id`. Item `id`s are returned by [POST /run-process]
     "destroyed_at": 4999, || null, // Nullable<Number>
     "parents": [40, 41], // Array<Number>
     "children": [43, 44] || null // Nullable<Array<Number>>
+    "timestamp": "2022-02-09T10:30:12.003Z" // Date (ISO)
     "metadata_keys": ["metadataKey1", ..."metadataKeyN"] // Array<String>
 }
 ```

--- a/app/api-v2/routes/item/{id}.js
+++ b/app/api-v2/routes/item/{id}.js
@@ -15,12 +15,14 @@ module.exports = function (apiService) {
 
       try {
         const result = await apiService.findItemById(id)
-
-        result.metadata_keys = getReadableMetadataKeys(result.metadata)
-        delete result.metadata // raw metadata is unreadable hashes
+        const { metadata, ...rest } = result
+        const response = {
+          ...rest,
+          metadata_keys: getReadableMetadataKeys(metadata),
+        }
 
         if (result.id === id) {
-          res.status(200).json(result)
+          res.status(200).json(response)
           return
         } else {
           res.status(404).json({

--- a/app/api-v2/routes/item/{id}.js
+++ b/app/api-v2/routes/item/{id}.js
@@ -17,6 +17,7 @@ module.exports = function (apiService) {
         const result = await apiService.findItemById(id)
 
         result.metadata_keys = getReadableMetadataKeys(result.metadata)
+        delete result.metadata // raw metadata is unreadable hashes
 
         if (result.id === id) {
           res.status(200).json(result)

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -337,11 +337,10 @@ async function getItem(tokenId) {
 
   if (tokenId) {
     await api.isReady
-    const rawItem = await api.query.simpleNftModule.tokensById(tokenId)
-    const item = rawItem.toJSON()
-    item.timestamp = await getTimestamp(item.created_at)
+    const item = (await api.query.simpleNftModule.tokensById(tokenId)).toJSON()
+    const timestamp = await getTimestamp(item.created_at)
 
-    response = item
+    response = { ...item, timestamp }
   }
 
   return response

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -339,7 +339,8 @@ async function getItem(tokenId) {
     await api.isReady
     const rawItem = await api.query.simpleNftModule.tokensById(tokenId)
     const item = rawItem.toJSON()
-    item.timestamp = getTimestamp(item.created_at)
+    item.timestamp = await getTimestamp(item.created_at)
+
     response = item
   }
 

--- a/helm/vitalam-api/Chart.yaml
+++ b/helm/vitalam-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-api
-appVersion: '2.7.0'
+appVersion: '2.7.1'
 description: A Helm chart for vitalam-api
-version: '2.7.0'
+version: '2.7.1'
 type: application
 dependencies:
   - name: vitalam-node

--- a/helm/vitalam-api/values.yaml
+++ b/helm/vitalam-api/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/vitalam-api
   pullPolicy: IfNotPresent
-  tag: 'v2.7.0'
+  tag: 'v2.7.1'
 
 vitalamNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-prettier": "^3.4.0",
         "mocha": "^9.2.0",
         "mock-jwks": "^1.0.1",
+        "moment": "^2.29.1",
         "nock": "^13.1.0",
         "nodemon": "^2.0.7",
         "nyc": "^15.1.0",
@@ -4373,6 +4374,15 @@
       },
       "peerDependencies": {
         "nock": "^11 || ^12 || ^13"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -10131,6 +10141,12 @@
         "node-forge": "^0.10.0",
         "node-rsa": "^0.4.2"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitalam-api",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitalam-api",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "mocha": "^9.2.0",
     "mock-jwks": "^1.0.1",
+    "moment": "^2.29.1",
     "nock": "^13.1.0",
     "nodemon": "^2.0.7",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalam-api",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "VITALam API",
   "repository": {
     "type": "git",

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -3,6 +3,7 @@ const createJWKSMock = require('mock-jwks').default
 const { describe, test, before } = require('mocha')
 const { expect } = require('chai')
 const nock = require('nock')
+const moment = require('moment')
 
 const { createHttpServer } = require('../../app/server')
 const {
@@ -139,7 +140,7 @@ describe('routes', function () {
     })
 
     describe('happy path', function () {
-      test('add and get item - single metadata FILE', async function () {
+      test.only('add and get item - single metadata FILE', async function () {
         const outputs = [
           { roles: defaultRole, metadata: { testFile: { type: 'FILE', value: './test/data/test_file_01.txt' } } },
         ]
@@ -153,6 +154,11 @@ describe('routes', function () {
         expect(getItemResult.status).to.equal(200)
         expect(getItemResult.body.id).to.equal(lastToken.body.id)
         expect(getItemResult.body.metadata_keys).to.deep.equal(['testFile'])
+
+        const timestamp = getItemResult.body.timestamp
+        expect(moment(timestamp, moment.ISO_8601, true).isValid()).to.be.true
+        let now = new Date().getTime()
+        expect(new Date(timestamp).getTime()).to.be.within(now - 6000, now)
       })
 
       test('add item that consumes a parent', async function () {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -140,7 +140,7 @@ describe('routes', function () {
     })
 
     describe('happy path', function () {
-      test.only('add and get item - single metadata FILE', async function () {
+      test('add and get item - single metadata FILE', async function () {
         const outputs = [
           { roles: defaultRole, metadata: { testFile: { type: 'FILE', value: './test/data/test_file_01.txt' } } },
         ]

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -154,11 +154,7 @@ describe('routes', function () {
         expect(getItemResult.status).to.equal(200)
         expect(getItemResult.body.id).to.equal(lastToken.body.id)
         expect(getItemResult.body.metadata_keys).to.deep.equal(['testFile'])
-
-        const timestamp = getItemResult.body.timestamp
-        expect(moment(timestamp, moment.ISO_8601, true).isValid()).to.be.true
-        let now = new Date().getTime()
-        expect(new Date(timestamp).getTime()).to.be.within(now - 6000, now)
+        expect(moment(getItemResult.body.timestamp, moment.ISO_8601, true).isValid()).to.be.true
       })
 
       test('add item that consumes a parent', async function () {


### PR DESCRIPTION
We want the API to serve the timestamp of tokens:

- [x] /item response now includes `timestamp` in ISO date format (2022-01-31T14:53:57Z)
- [x] test
- [x] README
- [x] cheeky extra change to remove `metadata` from GET `/item` because it just clogs the response with unreadable data like 
```
{
  '0x7465737446696c65000000000000000000000000000000000000000000000000': {
    file: '0x9fe57c9dddb1da90177136e6dd586d1ecb403e17c9e786ca8811b880fbd3ddf6'
  }
}
```
users use `/item/{id}/metadata/{metadata_key}` to get specific metadata
