### PR TITLE
Chore/bump versions

### DIFF
--- a/helm/vitalam-api/Chart.lock
+++ b/helm/vitalam-api/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: vitalam-node
   repository: https://digicatapult.github.io/vitalam-node/
-  version: 0.23.5
+  version: 0.24.1
 - name: vitalam-ipfs
   repository: https://digicatapult.github.io/vitalam-ipfs/
-  version: 1.2.3
-digest: sha256:10e37ea698e3e4362c651a4654d00f4f8352062f6a20adc3154ffeadac6ac4ea
-generated: "2022-02-04T13:31:35.721791Z"
+  version: 1.2.6
+digest: sha256:b8905ee76b92652fa5679d9985733cd95c4e8bfca35fc4a94863a9ecd92f8894
+generated: "2022-02-15T11:16:14.467211Z"

--- a/helm/vitalam-api/Chart.yaml
+++ b/helm/vitalam-api/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: vitalam-api
-appVersion: '2.8.0'
+appVersion: '2.8.1'
 description: A Helm chart for vitalam-api
-version: '2.8.0'
+version: '2.8.1'
 type: application
 dependencies:
   - name: vitalam-node
-    version: '0.23.5'
+    version: '0.24.1'
     repository: https://digicatapult.github.io/vitalam-node/
     condition: vitalamNode.enabled
     alias: vitalamNode
   - name: vitalam-ipfs
-    version: '1.2.3'
+    version: '1.2.6'
     repository: https://digicatapult.github.io/vitalam-ipfs/
     condition: vitalamIpfs.enabled
     alias: vitalamIpfs

--- a/helm/vitalam-api/values.yaml
+++ b/helm/vitalam-api/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/vitalam-api
   pullPolicy: IfNotPresent
-  tag: 'v2.8.0'
+  tag: 'v2.8.1'
 
 vitalamNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.0",
         "mocha": "^9.2.0",
-        "mock-jwks": "^1.0.1",
+        "mock-jwks": "^1.0.3",
         "moment": "^2.29.1",
         "nock": "^13.1.0",
         "nodemon": "^2.0.7",
@@ -4362,14 +4362,14 @@
       }
     },
     "node_modules/mock-jwks": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mock-jwks/-/mock-jwks-1.0.1.tgz",
-      "integrity": "sha512-6rA82krn+vIQ500EWv1xwk66/OTLKIx9h3sfa1OG3TgEip223Ellww5BbxD0fi6YP6e9KS9wEgcSWo9YmsX+2A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mock-jwks/-/mock-jwks-1.0.3.tgz",
+      "integrity": "sha512-/O+mwJUp9FITzXqMUWz9mxoQSUe2DTgx7J0TiM02BxExGM47/llZRAEDiuJTtIGCFa11J3rAuSPE2BZw2kTFIQ==",
       "dev": true,
       "dependencies": {
         "base64-url": "^2.2.0",
         "jsonwebtoken": "^8.2.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.0.0",
         "node-rsa": "^0.4.2"
       },
       "peerDependencies": {
@@ -4497,12 +4497,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "dev": true,
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -10131,14 +10131,14 @@
       }
     },
     "mock-jwks": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mock-jwks/-/mock-jwks-1.0.1.tgz",
-      "integrity": "sha512-6rA82krn+vIQ500EWv1xwk66/OTLKIx9h3sfa1OG3TgEip223Ellww5BbxD0fi6YP6e9KS9wEgcSWo9YmsX+2A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mock-jwks/-/mock-jwks-1.0.3.tgz",
+      "integrity": "sha512-/O+mwJUp9FITzXqMUWz9mxoQSUe2DTgx7J0TiM02BxExGM47/llZRAEDiuJTtIGCFa11J3rAuSPE2BZw2kTFIQ==",
       "dev": true,
       "requires": {
         "base64-url": "^2.2.0",
         "jsonwebtoken": "^8.2.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.0.0",
         "node-rsa": "^0.4.2"
       }
     },
@@ -10228,9 +10228,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "dev": true
     },
     "node-gyp-build": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitalam-api",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitalam-api",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalam-api",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "VITALam API",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
     "mocha": "^9.2.0",
-    "mock-jwks": "^1.0.1",
+    "mock-jwks": "^1.0.3",
     "moment": "^2.29.1",
     "nock": "^13.1.0",
     "nodemon": "^2.0.7",


### PR DESCRIPTION
Uses new version of the `vitalam-node` and `vitalam-ipfs` helm charts
Upgrades insecure dependencies `mock-jwks`